### PR TITLE
Fix CI: adapt to libKriging .travis-ci/ → tools/ rename

### DIFF
--- a/.github/workflows/install_github.yml
+++ b/.github/workflows/install_github.yml
@@ -62,7 +62,7 @@ jobs:
           fi
           # Add --insecure to workaround missing certificates on Windows
           curl --insecure --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -LO "https://raw.githubusercontent.com/libKriging/rlibkriging/${REF}/tools/install_packages.R"
-          Rscript --no-save ./install_packages.R devtools
+          Rscript --no-save ./install_packages.R remotes devtools
 
       - name: install_github (with tag)
         if: github.ref_type == 'tag'

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -20,9 +20,14 @@ if test -z "${R_HOME}"; then
    as_fn_error $? "Could not determine R_HOME." "$LINENO" 5
 fi
 
-# Static libKriging build (using libK/.ci)
+# Static libKriging build (using libK CI scripts)
 cd src/libK
-CI=`ls -a | grep travis-ci`
+# Find CI scripts directory: 'tools' (new name since libKriging PR#314), or '.travis-ci'/'travis-ci' (legacy)
+if [ -d tools/common ]; then
+  CI=tools
+else
+  CI=`ls -a | grep travis-ci`
+fi
 echo "CI: "$CI
 
 {
@@ -73,7 +78,7 @@ fi
 BUILD_TEST=false \
 MODE=Release \
 EXTRA_CMAKE_OPTIONS="${EXTRA_CMAKE_OPTIONS:-} -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_SHARED_LIBS=${MAKE_SHARED_LIBS} -DSTATIC_LIB=${STATIC_LIB} -DEXTRA_SYSTEM_LIBRARY_PATH=${EXTRA_SYSTEM_LIBRARY_PATH}" \
-$CI/linux-macos/build.sh # should support '.travis-ci' or 'travis-ci'"
+$CI/linux-macos/build.sh
 
 # Clean up CMake temp directories immediately after build
 find /tmp -maxdepth 1 -name "tmp.*" -type d -user $(id -u) -mmin -10 2>/dev/null | while read dir; do

--- a/tools/gitmodules-shas
+++ b/tools/gitmodules-shas
@@ -1,5 +1,5 @@
 # This file records the specific commit SHAs for each submodule
 # It is automatically generated and should be updated when submodules are updated
 # Format: <submodule_path> <commit_sha>
-src/libK bcbdab25651b7790ce611ef6fa448b28644fc505
+src/libK 169337800d6dcbaa64c203186d3bdc34d291bafa
 src/slapack 72a7f3753e02b0471e93296f2b22877c6fee7328

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -233,10 +233,12 @@ echo "Renaming hidden files for CRAN compliance..."
 if [ -d $LIBKRIGING_SRC_PATH/.travis-ci ]; then
   echo "  → Renaming .travis-ci to travis-ci..."
   mv $LIBKRIGING_SRC_PATH/.travis-ci $LIBKRIGING_SRC_PATH/travis-ci
+  # rename .travis-ci in travis-ci everywhere. Use temp .bak for sed OSX compliance
+  echo "  → Updating .travis-ci references in shell scripts..."
+  find $LIBKRIGING_SRC_PATH -type f -name *.sh -exec sed -i.bak "s/\.travis-ci/travis-ci/g" {} +
+else
+  echo "  ✓ No .travis-ci directory (already renamed to tools/)"
 fi
-# rename .travis-ci in travis-ci everywhere. Use temp .bak for sed OSX compliance
-echo "  → Updating .travis-ci references in shell scripts..."
-find $LIBKRIGING_SRC_PATH -type f -name *.sh -exec sed -i.bak "s/\.travis-ci/travis-ci/g" {} +
 echo "  → Removing git rev-parse dependencies..."
 # remove usages of 'git rev-parse', which is not a standard requirement fo R
 GIT_ROOT=$(pwd);


### PR DESCRIPTION
## Problem

The latest libKriging submodule update (PR#314) renamed `.travis-ci/` to `tools/`. This broke CI in two ways:

### Build failure (`R-CMD-check`, `submit-CRAN`, `R-CMD-INSTALL-build`)
`tools/build.sh` used `ls -a | grep travis-ci` to find CI scripts inside `src/libK/`. Since `.travis-ci/` no longer exists, the cmake build never ran → no `inst/include` generated → `lkalloc.hpp: No such file or directory`.

### install_github failure
`devtools` 2.5.0 deprecated `install_github()` and requires the `remotes` package, which wasn't being installed.

## Fix

- **`tools/build.sh`**: Detect `tools/common` (new layout) before falling back to `travis-ci` (legacy)
- **`tools/setup.sh`**: Only run `.travis-ci` rename when directory actually exists
- **`install_github.yml`**: Install `remotes` alongside `devtools`