### PR TITLE
fix: update gitmodules-shas to match libK submodule (102ff520)

### DIFF
--- a/tools/gitmodules-shas
+++ b/tools/gitmodules-shas
@@ -1,5 +1,5 @@
 # This file records the specific commit SHAs for each submodule
 # It is automatically generated and should be updated when submodules are updated
 # Format: <submodule_path> <commit_sha>
-src/libK 148585923ee7655b1d2a0afb02146b1e8b450116
+src/libK 102ff520e6bcd2fd16c3d14e31cf008cd0f30f5b
 src/slapack 72a7f3753e02b0471e93296f2b22877c6fee7328


### PR DESCRIPTION
The `tools/gitmodules-shas` file was not updated when the `src/libK` submodule was bumped to `102ff520` (which merged the fork-after-threads deadlock fix, PR libKriging/libKriging#319).

This causes the `check-gitmodules-shas` CI job to fail.

Fix: update `src/libK` SHA from `14858592` → `102ff520e6bcd2fd16c3d14e31cf008cd0f30f5b`.