### PR TITLE
release: prepare CRAN submission 1.1-0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -32,3 +32,5 @@
 ^src/.*\.dll$
 
 ^compat$
+
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rlibkriging
 Type: Package
 Title: Kriging Models using the 'libKriging' Library
-Version: 1.0-0
-Date: 2026-05-12
+Version: 1.1-0
+Date: 2026-07-11
 Authors@R:
     c(person(given = "Yann",
              family = "Richet",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,28 @@
+# rlibkriging 1.1-0
+
+## New features
+
+* New `NestedKriging` class: a divide-and-conquer Gaussian process for large
+  designs. The data are partitioned into groups, one `Kriging` submodel is
+  fitted per group with a common prior, and predictions are aggregated with the
+  optimal nested-kriging aggregation (`"NK"`, interpolating) or a
+  product-of-experts rule (`"PoE"`, `"gPoE"`, `"BCM"`, `"rBCM"`).
+
+* New Vecchia approximated log-likelihood objective for large designs: fit a
+  `Kriging` model with `objective = "VLL(m)"` (or `"VLL"`, default `m = 30`),
+  costing O(n m^3) per evaluation instead of O(n^3).
+
+## Changes
+
+* `Kriging()` / `fit()`: `objective` now also accepts `"VLL"` / `"VLL(m)"`, and
+  `regmodel` now accepts `"quadratic"`.
+
+* `Kriging()` / `fit()`: the `noise` argument has been moved to the **last**
+  position, for consistency with `WarpKriging` and the other language bindings.
+  Code that passes `noise` by name is unaffected; positional calls that relied
+  on `noise` being the 4th argument must be updated.
+
+## Fixes
+
+* Fix a possible deadlock when forking after threads were created.
+* Numerous build and portability fixes (Windows, macOS deployment target).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,39 @@
+## Submission
+
+This is a feature update of rlibkriging (1.1-0), updating the current CRAN
+version 0.9-3. (Version 1.0-0 was a GitHub-only release and was not submitted
+to CRAN.)
+
+Main user-visible changes (see NEWS.md):
+
+* new `NestedKriging` class (divide-and-conquer GP for large designs);
+* new Vecchia approximated log-likelihood fit objective `"VLL(m)"`;
+* `objective` also accepts `"VLL"`/`"VLL(m)"` and `regmodel` accepts
+  `"quadratic"`; the `noise` argument of `Kriging()`/`fit()` moved to the last
+  position (named calls are unaffected).
+
+## Test environments
+
+Tested via GitHub Actions and R-hub on:
+
+* Ubuntu 22.04, R release, R-devel and R oldrel-1
+* macOS (Apple Silicon), R release, R-devel and R oldrel-1
+* Windows Server, R release, R-devel and R oldrel-1
+
+using `R CMD check --as-cran`.
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* checking installed package size ... NOTE
+  installed size is ~40Mb (sub-directories `lib`, `include`, `libs`).
+
+  rlibkriging bundles the 'libKriging' C++ library together with its C++
+  dependencies (Armadillo and lbfgsb) as source and static libraries; the size
+  comes entirely from these vendored components, as in the previous CRAN
+  release. There is no run-time download.
+
+## Reverse dependencies
+
+There are no reverse dependencies on CRAN. <!-- please confirm before submitting -->


### PR DESCRIPTION
Prepares the CRAN submission of **rlibkriging 1.1-0** (updating the current CRAN version 0.9-3).

## Changes
- **DESCRIPTION**: `Version: 1.1-0`, refreshed `Date`.
- **NEWS.md** (new): 1.1-0 changelog — `NestedKriging`, Vecchia `objective="VLL(m)"`, `objective`/`regmodel`/`noise` argument changes, fixes.
- **cran-comments.md** (new): test environments, `R CMD check --as-cran` results (0 errors / 0 warnings / 1 note), justification of the installed-size NOTE (bundled libKriging + Armadillo/lbfgsb), reverse-dependencies line.
- **.Rbuildignore**: exclude `cran-comments.md` from the built package.

## Before submitting (maintainer)
- Confirm the reverse-dependencies line in `cran-comments.md`.
- Ensure the `submit-CRAN` / `R-CMD-check` workflows are green on this branch (0 errors / 0 warnings; the installed-size NOTE is expected).
- Submit with `devtools::submit_cran()` (or the CRAN web form) and confirm via the maintainer email — this is a manual maintainer step, not automated here.

Note: `NEWS.md` is intentionally shipped (package changelog); `cran-comments.md` is not.
